### PR TITLE
Prefer docblock annotations above reflected type for properties

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -540,31 +540,33 @@ class JsonMapper
         }
         if ($rprop !== null) {
             if ($rprop->isPublic() || $this->bIgnoreVisibility) {
-                if (PHP_VERSION_ID >= 70400 && $rprop->hasType()) {
-                    $rPropType = $rprop->getType();
-                    $propTypeName = $rPropType->getName();
-
-                    if ($this->isSimpleType($propTypeName)) {
-                        return array(
-                            true,
-                            $rprop,
-                            $propTypeName,
-                            $rPropType->allowsNull()
-                        );
-                    }
-
-                    return array(
-                        true,
-                        $rprop,
-                        '\\' . $propTypeName,
-                        $rPropType->allowsNull()
-                    );
-                }
-
                 $docblock    = $rprop->getDocComment();
                 $annotations = static::parseAnnotations($docblock);
 
                 if (!isset($annotations['var'][0])) {
+                    // If there is no annotations (higher priority) inspect
+                    // if there's a scalar type being defined
+                    if (PHP_VERSION_ID >= 70400 && $rprop->hasType()) {
+                        $rPropType = $rprop->getType();
+                        $propTypeName = $rPropType->getName();
+
+                        if ($this->isSimpleType($propTypeName)) {
+                            return array(
+                              true,
+                              $rprop,
+                              $propTypeName,
+                              $rPropType->allowsNull()
+                            );
+                        }
+
+                        return array(
+                          true,
+                          $rprop,
+                          '\\'.$propTypeName,
+                          $rPropType->allowsNull()
+                        );
+                    }
+
                     return array(true, $rprop, null, false);
                 }
 

--- a/tests/PHP74_StrictTypesTest.php
+++ b/tests/PHP74_StrictTypesTest.php
@@ -12,7 +12,7 @@
  */
 class PHP74_StrictTypesTest extends \PHPUnit\Framework\TestCase
 {
-    const TEST_DATA = '{"id": 123, "importedNs": {"name": "Name"}, "otherNs": {"name": "Foo"}, "withoutType": "anything", "docDefinedType": {"name": "Name"}, "nullable": "value"}';
+    const TEST_DATA = '{"id": 123, "importedNs": {"name": "Name"}, "otherNs": {"name": "Foo"}, "withoutType": "anything", "docDefinedType": {"name": "Name"}, "nullable": "value", "fooArray": [{"name": "Foo 1"}, {"name": "Foo 2"}]}';
 
     /**
      * Sets up test cases loading required classes.
@@ -44,5 +44,9 @@ class PHP74_StrictTypesTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(\othernamespace\Foo::class, $sn->otherNs);
         $this->assertEquals('anything', $sn->withoutType);
         $this->assertTrue(isset($sn->nullable));
+        $this->assertIsArray($sn->fooArray);
+        $this->assertCount(2, $sn->fooArray);
+        $this->assertInstanceOf(\othernamespace\Foo::class, $sn->fooArray[0]);
+        $this->assertInstanceOf(\othernamespace\Foo::class, $sn->fooArray[1]);
     }
 }

--- a/tests/namespacetest/PhpStrictTypes.php
+++ b/tests/namespacetest/PhpStrictTypes.php
@@ -17,4 +17,9 @@ class PhpStrictTypes
     public $withoutType;
 
     public ?string $nullable;
+
+    /**
+     * @var \othernamespace\Foo[] Array containing foos.
+     */
+    public array $fooArray;
 }


### PR DESCRIPTION
This fixes detection of the specific type of array properties.